### PR TITLE
Slightly better log macro names

### DIFF
--- a/include/csys/command.h
+++ b/include/csys/command.h
@@ -112,9 +112,9 @@ namespace csys
             catch (Exception &ae)
             {
                 // Error happened with parsing
-                return Item(ERROR) << (m_Name.m_String + ": " + ae.what());
+                return Item(ITEM_TYPE_ERROR) << (m_Name.m_String + ": " + ae.what());
             }
-            return Item(NONE);
+            return Item(ITEM_TYPE_NONE);
         }
 
         /*!
@@ -240,12 +240,12 @@ namespace csys
             catch (Exception &ae)
             {
                 // Command had something passed into it
-                return Item(ERROR) << (m_Name.m_String + ": " + ae.what());
+                return Item(ITEM_TYPE_ERROR) << (m_Name.m_String + ": " + ae.what());
             }
 
             // Call function
             m_Function();
-            return Item(NONE);
+            return Item(ITEM_TYPE_NONE);
         }
 
         /*!

--- a/include/csys/command.h
+++ b/include/csys/command.h
@@ -112,9 +112,9 @@ namespace csys
             catch (Exception &ae)
             {
                 // Error happened with parsing
-                return Item(ITEM_TYPE_ERROR) << (m_Name.m_String + ": " + ae.what());
+                return Item(LOG_TYPE_ERROR) << (m_Name.m_String + ": " + ae.what());
             }
-            return Item(ITEM_TYPE_NONE);
+            return Item(LOG_TYPE_NONE);
         }
 
         /*!
@@ -240,12 +240,12 @@ namespace csys
             catch (Exception &ae)
             {
                 // Command had something passed into it
-                return Item(ITEM_TYPE_ERROR) << (m_Name.m_String + ": " + ae.what());
+                return Item(LOG_TYPE_ERROR) << (m_Name.m_String + ": " + ae.what());
             }
 
             // Call function
             m_Function();
-            return Item(ITEM_TYPE_NONE);
+            return Item(LOG_TYPE_NONE);
         }
 
         /*!

--- a/include/csys/item.h
+++ b/include/csys/item.h
@@ -25,12 +25,12 @@ namespace csys
      */
     enum ItemType
     {
-        ITEM_TYPE_COMMAND = 0,
-        ITEM_TYPE_LOG,
-        ITEM_TYPE_WARNING,
-        ITEM_TYPE_ERROR,
-        ITEM_TYPE_INFO,
-        ITEM_TYPE_NONE
+        LOG_TYPE_COMMAND = 0,
+        LOG_TYPE_LOG,
+        LOG_TYPE_WARNING,
+        LOG_TYPE_ERROR,
+        LOG_TYPE_INFO,
+        LOG_TYPE_NONE
     };
 
     struct CSYS_API Item
@@ -41,7 +41,7 @@ namespace csys
          * \param type
          *      Item type to be stored
          */
-        explicit Item(ItemType type = ItemType::ITEM_TYPE_LOG);
+        explicit Item(ItemType type = ItemType::LOG_TYPE_LOG);
 
         /*!
          * \brief

--- a/include/csys/item.h
+++ b/include/csys/item.h
@@ -25,12 +25,12 @@ namespace csys
      */
     enum ItemType
     {
-        COMMAND = 0,
-        LOG,
-        WARNING,
-        ERROR,
-        INFO,
-        NONE
+        ITEM_TYPE_COMMAND = 0,
+        ITEM_TYPE_LOG,
+        ITEM_TYPE_WARNING,
+        ITEM_TYPE_ERROR,
+        ITEM_TYPE_INFO,
+        ITEM_TYPE_NONE
     };
 
     struct CSYS_API Item
@@ -41,7 +41,7 @@ namespace csys
          * \param type
          *      Item type to be stored
          */
-        explicit Item(ItemType type = ItemType::LOG);
+        explicit Item(ItemType type = ItemType::ITEM_TYPE_LOG);
 
         /*!
          * \brief

--- a/include/csys/item.inl
+++ b/include/csys/item.inl
@@ -39,17 +39,17 @@ namespace csys
     {
         switch (m_Type)
         {
-            case COMMAND:
+            case ITEM_TYPE_COMMAND:
                 return s_Command.data() + m_Data;
-            case LOG:
+            case ITEM_TYPE_LOG:
                 return '\t' + m_Data;
-            case WARNING:
+            case ITEM_TYPE_WARNING:
                 return s_Warning.data() + m_Data;
-            case ERROR:
+            case ITEM_TYPE_ERROR:
                 return s_Error.data() + m_Data;
-            case INFO:
+            case ITEM_TYPE_INFO:
                 return m_Data;
-            case NONE:
+            case ITEM_TYPE_NONE:
             default:
                 return "";
         }

--- a/include/csys/item.inl
+++ b/include/csys/item.inl
@@ -39,17 +39,17 @@ namespace csys
     {
         switch (m_Type)
         {
-            case ITEM_TYPE_COMMAND:
+            case LOG_TYPE_COMMAND:
                 return s_Command.data() + m_Data;
-            case ITEM_TYPE_LOG:
+            case LOG_TYPE_LOG:
                 return '\t' + m_Data;
-            case ITEM_TYPE_WARNING:
+            case LOG_TYPE_WARNING:
                 return s_Warning.data() + m_Data;
-            case ITEM_TYPE_ERROR:
+            case LOG_TYPE_ERROR:
                 return s_Error.data() + m_Data;
-            case ITEM_TYPE_INFO:
+            case LOG_TYPE_INFO:
                 return m_Data;
-            case ITEM_TYPE_NONE:
+            case LOG_TYPE_NONE:
             default:
                 return "";
         }

--- a/include/csys/system.h
+++ b/include/csys/system.h
@@ -106,7 +106,7 @@ namespace csys
          * \return
          *      Reference to console items obj
          */
-        ItemLog &Log(ItemType type = ItemType::ITEM_TYPE_LOG);
+        ItemLog &Log(ItemType type = ItemType::LOG_TYPE_LOG);
 
         /*!
          * \brief
@@ -169,7 +169,7 @@ namespace csys
             // Check if command has a name
             else if (range.first == name.End())
             {
-                Log(ITEM_TYPE_ERROR) << "Empty command name given" << csys::endl;
+                Log(LOG_TYPE_ERROR) << "Empty command name given" << csys::endl;
                 return;
             }
 
@@ -192,7 +192,7 @@ namespace csys
 
             // Make help command for command just added
             auto help = [this, command_name]() {
-                Log(ITEM_TYPE_LOG) << m_Commands[command_name]->Help() << csys::endl;
+                Log(LOG_TYPE_LOG) << m_Commands[command_name]->Help() << csys::endl;
             };
 
             m_Commands["help " + command_name] = std::make_unique<Command<decltype(help)>>("help " + command_name,
@@ -315,7 +315,7 @@ namespace csys
 
             // Get Command
             const auto GetFunction = [this, &var]() {
-                m_ItemLog.log(ITEM_TYPE_LOG) << var << endl;
+                m_ItemLog.log(LOG_TYPE_LOG) << var << endl;
             };
 
             // Register get command

--- a/include/csys/system.h
+++ b/include/csys/system.h
@@ -106,7 +106,7 @@ namespace csys
          * \return
          *      Reference to console items obj
          */
-        ItemLog &Log(ItemType type = ItemType::LOG);
+        ItemLog &Log(ItemType type = ItemType::ITEM_TYPE_LOG);
 
         /*!
          * \brief
@@ -169,7 +169,7 @@ namespace csys
             // Check if command has a name
             else if (range.first == name.End())
             {
-                Log(ERROR) << "Empty command name given" << csys::endl;
+                Log(ITEM_TYPE_ERROR) << "Empty command name given" << csys::endl;
                 return;
             }
 
@@ -192,7 +192,7 @@ namespace csys
 
             // Make help command for command just added
             auto help = [this, command_name]() {
-                Log(LOG) << m_Commands[command_name]->Help() << csys::endl;
+                Log(ITEM_TYPE_LOG) << m_Commands[command_name]->Help() << csys::endl;
             };
 
             m_Commands["help " + command_name] = std::make_unique<Command<decltype(help)>>("help " + command_name,
@@ -315,7 +315,7 @@ namespace csys
 
             // Get Command
             const auto GetFunction = [this, &var]() {
-                m_ItemLog.log(LOG) << var << endl;
+                m_ItemLog.log(ITEM_TYPE_LOG) << var << endl;
             };
 
             // Register get command

--- a/include/csys/system.inl
+++ b/include/csys/system.inl
@@ -107,7 +107,7 @@ namespace csys
             return;
 
         // Log command.
-        Log(csys::ItemType::COMMAND) << line << csys::endl;
+        Log(csys::ItemType::ITEM_TYPE_COMMAND) << line << csys::endl;
 
         // Parse command line.
         ParseCommandLine(line);
@@ -121,12 +121,12 @@ namespace csys
         // Exit if not found.
         if (script_pair == m_Scripts.end())
         {
-            m_ItemLog.log(ERROR) << "Script \"" << script_name << "\" not found" << csys::endl;
+            m_ItemLog.log(ITEM_TYPE_ERROR) << "Script \"" << script_name << "\" not found" << csys::endl;
             return;
         }
 
         // About to run script.
-        m_ItemLog.log(INFO) << "Running \"" << script_name << "\"" << csys::endl;
+        m_ItemLog.log(ITEM_TYPE_INFO) << "Running \"" << script_name << "\"" << csys::endl;
 
         // Load if script is empty.
         if (script_pair->second->Data().empty())
@@ -137,7 +137,7 @@ namespace csys
             }
             catch (csys::Exception &e)
             {
-                Log(ERROR) << e.what() << csys::endl;
+                Log(ITEM_TYPE_ERROR) << e.what() << csys::endl;
             }
         }
 
@@ -272,7 +272,7 @@ namespace csys
             // Try to get variable name
             if ((range = line.NextPoi(line_index)).first == line.End())
             {
-                Log(ERROR) << s_ErrorNoVar << endl;
+                Log(ITEM_TYPE_ERROR) << s_ErrorNoVar << endl;
                 return;
             } else
                 // Append variable name.
@@ -282,7 +282,7 @@ namespace csys
         // Get runnable command
         auto command = m_Commands.find(command_name);
         if (command == m_Commands.end())
-            Log(ERROR) << s_ErrorSetGetNotFound << endl;
+            Log(ITEM_TYPE_ERROR) << s_ErrorSetGetNotFound << endl;
             // Run the command
         else
         {
@@ -293,7 +293,7 @@ namespace csys
             auto cmd_out = (*command->second)(arguments);
 
             // Log output.
-            if (cmd_out.m_Type != NONE)
+            if (cmd_out.m_Type != ITEM_TYPE_NONE)
                 m_ItemLog.Items().emplace_back(cmd_out);
         }
     }

--- a/include/csys/system.inl
+++ b/include/csys/system.inl
@@ -107,7 +107,7 @@ namespace csys
             return;
 
         // Log command.
-        Log(csys::ItemType::ITEM_TYPE_COMMAND) << line << csys::endl;
+        Log(csys::ItemType::LOG_TYPE_COMMAND) << line << csys::endl;
 
         // Parse command line.
         ParseCommandLine(line);
@@ -121,12 +121,12 @@ namespace csys
         // Exit if not found.
         if (script_pair == m_Scripts.end())
         {
-            m_ItemLog.log(ITEM_TYPE_ERROR) << "Script \"" << script_name << "\" not found" << csys::endl;
+            m_ItemLog.log(LOG_TYPE_ERROR) << "Script \"" << script_name << "\" not found" << csys::endl;
             return;
         }
 
         // About to run script.
-        m_ItemLog.log(ITEM_TYPE_INFO) << "Running \"" << script_name << "\"" << csys::endl;
+        m_ItemLog.log(LOG_TYPE_INFO) << "Running \"" << script_name << "\"" << csys::endl;
 
         // Load if script is empty.
         if (script_pair->second->Data().empty())
@@ -137,7 +137,7 @@ namespace csys
             }
             catch (csys::Exception &e)
             {
-                Log(ITEM_TYPE_ERROR) << e.what() << csys::endl;
+                Log(LOG_TYPE_ERROR) << e.what() << csys::endl;
             }
         }
 
@@ -272,7 +272,7 @@ namespace csys
             // Try to get variable name
             if ((range = line.NextPoi(line_index)).first == line.End())
             {
-                Log(ITEM_TYPE_ERROR) << s_ErrorNoVar << endl;
+                Log(LOG_TYPE_ERROR) << s_ErrorNoVar << endl;
                 return;
             } else
                 // Append variable name.
@@ -282,7 +282,7 @@ namespace csys
         // Get runnable command
         auto command = m_Commands.find(command_name);
         if (command == m_Commands.end())
-            Log(ITEM_TYPE_ERROR) << s_ErrorSetGetNotFound << endl;
+            Log(LOG_TYPE_ERROR) << s_ErrorSetGetNotFound << endl;
             // Run the command
         else
         {
@@ -293,7 +293,7 @@ namespace csys
             auto cmd_out = (*command->second)(arguments);
 
             // Log output.
-            if (cmd_out.m_Type != ITEM_TYPE_NONE)
+            if (cmd_out.m_Type != LOG_TYPE_NONE)
                 m_ItemLog.Items().emplace_back(cmd_out);
         }
     }

--- a/src/imgui_console.cpp
+++ b/src/imgui_console.cpp
@@ -218,7 +218,7 @@ void ImGuiConsole::LogWindow()
                 continue;
 
             // Spacing between commands.
-            if (item.m_Type == csys::COMMAND)
+            if (item.m_Type == csys::ITEM_TYPE_COMMAND)
             {
                 if (m_TimeStamps) ImGui::PushTextWrapPos(ImGui::GetColumnWidth() - timestamp_width);    // Wrap before timestamps start.
                 if (count++ != 0) ImGui::Dummy(ImVec2(-1, ImGui::GetFontSize()));                            // No space for the first command.
@@ -238,7 +238,7 @@ void ImGuiConsole::LogWindow()
 
 
             // Time stamp.
-            if (item.m_Type == csys::COMMAND && m_TimeStamps)
+            if (item.m_Type == csys::ITEM_TYPE_COMMAND && m_TimeStamps)
             {
                 // No wrap for timestamps
                 ImGui::PopTextWrapPos();
@@ -485,10 +485,10 @@ int ImGuiConsole::InputCallback(ImGuiInputTextCallbackData *data)
                 // Display suggestions on console.
                 if (!console->m_CmdSuggestions.empty())
                 {
-                    console->m_ConsoleSystem.Log(csys::COMMAND) << "Suggestions: " << csys::endl;
+                    console->m_ConsoleSystem.Log(csys::ITEM_TYPE_COMMAND) << "Suggestions: " << csys::endl;
 
                     for (const auto &suggestion : console->m_CmdSuggestions)
-                        console->m_ConsoleSystem.Log(csys::LOG) << suggestion << csys::endl;
+                        console->m_ConsoleSystem.Log(csys::ITEM_TYPE_LOG) << suggestion << csys::endl;
 
                     console->m_CmdSuggestions.clear();
                 }

--- a/src/imgui_console.cpp
+++ b/src/imgui_console.cpp
@@ -218,7 +218,7 @@ void ImGuiConsole::LogWindow()
                 continue;
 
             // Spacing between commands.
-            if (item.m_Type == csys::ITEM_TYPE_COMMAND)
+            if (item.m_Type == csys::LOG_TYPE_COMMAND)
             {
                 if (m_TimeStamps) ImGui::PushTextWrapPos(ImGui::GetColumnWidth() - timestamp_width);    // Wrap before timestamps start.
                 if (count++ != 0) ImGui::Dummy(ImVec2(-1, ImGui::GetFontSize()));                            // No space for the first command.
@@ -238,7 +238,7 @@ void ImGuiConsole::LogWindow()
 
 
             // Time stamp.
-            if (item.m_Type == csys::ITEM_TYPE_COMMAND && m_TimeStamps)
+            if (item.m_Type == csys::LOG_TYPE_COMMAND && m_TimeStamps)
             {
                 // No wrap for timestamps
                 ImGui::PopTextWrapPos();
@@ -485,10 +485,10 @@ int ImGuiConsole::InputCallback(ImGuiInputTextCallbackData *data)
                 // Display suggestions on console.
                 if (!console->m_CmdSuggestions.empty())
                 {
-                    console->m_ConsoleSystem.Log(csys::ITEM_TYPE_COMMAND) << "Suggestions: " << csys::endl;
+                    console->m_ConsoleSystem.Log(csys::LOG_TYPE_COMMAND) << "Suggestions: " << csys::endl;
 
                     for (const auto &suggestion : console->m_CmdSuggestions)
-                        console->m_ConsoleSystem.Log(csys::ITEM_TYPE_LOG) << suggestion << csys::endl;
+                        console->m_ConsoleSystem.Log(csys::LOG_TYPE_LOG) << suggestion << csys::endl;
 
                     console->m_CmdSuggestions.clear();
                 }


### PR DESCRIPTION
Using `ERROR`, for example, as a macro name might be an issue in some contexts.